### PR TITLE
Pin Dockerfile to google/cloud-sdk:528.0.0-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM google/cloud-sdk:alpine
+FROM google/cloud-sdk:528.0.0-alpine
 #docker:19.03.2
 
 LABEL "maintainer"="whoan <juaneabadie@gmail.com>"


### PR DESCRIPTION
This should solve "`docker` command not found" issues. The upstream image recently chose to [remove `docker` for security reasons](https://hub.docker.com/r/google/cloud-sdk). **A good reminder to always pin your dependencies!** 

<img width="1520" alt="image" src="https://github.com/user-attachments/assets/f3d839c9-961f-4e06-8405-6e718ff4c49d" />

<img width="1589" alt="image" src="https://github.com/user-attachments/assets/67b520e7-3dee-4665-a4c7-d5980b8b0c37" />

